### PR TITLE
Update ambuild tooling to work on both Windows / Linux with boost distrib

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -27,6 +27,7 @@ class ExtensionConfig(object):
     self.extensions = []
     self.sm_root = None
     self.mms_root = None
+    self.boost_root = None
 
   @property
   def tag(self):
@@ -58,6 +59,10 @@ class ExtensionConfig(object):
         self.mms_root = ResolveEnvPath('MMSOURCE', 'metamod-source')
       if not self.mms_root:
         self.mms_root = ResolveEnvPath('MMSOURCE_DEV', 'mmsource-central')
+
+  def detectBoost(self):
+    if builder.options.boost_path:
+      self.boost_root = builder.options.boost_path
 
   def configure(self):
     cxx = builder.DetectCompilers()
@@ -156,13 +161,14 @@ class ExtensionConfig(object):
       '_CRT_SECURE_NO_WARNINGS',
       '_CRT_NONSTDC_NO_DEPRECATE',
       '_ITERATOR_DEBUG_LEVEL=0',
+      '_WIN32_WINNT=0x0601',
     ]
     cxx.cflags += [
       '/W3',
     ]
     cxx.cxxflags += [
       '/EHsc',
-      '/GR-',
+      # '/GR-', # boost needs RTTI enabled
       '/TP',
     ]
     cxx.linkflags += [
@@ -180,6 +186,9 @@ class ExtensionConfig(object):
       'odbc32.lib',
       'odbccp32.lib',
     ]
+
+    # setup boost libraries
+    cxx.linkflags += ['/LIBPATH:"' + os.path.join(self.boost_root, 'stage', 'x86', 'lib') + '"']
 
     if builder.options.opt == '1':
       cxx.cflags += ['/Ox', '/Zo']
@@ -224,6 +233,7 @@ class ExtensionConfig(object):
       os.path.join(self.sm_root, 'sourcepawn', 'include'),
       os.path.join(self.sm_root, 'public', 'amtl', 'amtl'),
       os.path.join(self.sm_root, 'public', 'amtl'),
+      os.path.join(self.boost_root)
     ]
     return compiler
 
@@ -235,6 +245,7 @@ class ExtensionConfig(object):
 Extension = ExtensionConfig()
 Extension.detectMetaMod()
 Extension.detectSourceMod()
+Extension.detectBoost()
 Extension.configure()
 
 # Add additional buildscripts here

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -205,7 +205,10 @@ class ExtensionConfig(object):
     cxx.defines += ['_LINUX', 'POSIX']
     
     # link flags based off of socket Makefile
-    cxx.linkflags += ['-lpthread', '-Wl,-Bstatic', '-lm', '-lboost_thread', '-lboost_system', '-lstdc++', '-Wl,-Bdynamic']
+    cxx.linkflags += ['-lpthread', '-Wl,-Bstatic', '-lm', '-lstdc++']
+    cxx.linkflags += ['-L', os.path.join(self.boost_root, 'stage', 'x86', 'lib')]
+    cxx.linkflags += ['-lboost_thread']
+    cxx.linkflags += ['-Wl,-Bdynamic']
     if cxx.vendor == 'gcc':
       cxx.linkflags += ['-static-libgcc']
     elif cxx.vendor == 'clang':

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -26,7 +26,6 @@ class ExtensionConfig(object):
   def __init__(self):
     self.extensions = []
     self.sm_root = None
-    self.mms_root = None
     self.boost_root = None
 
   @property
@@ -50,19 +49,11 @@ class ExtensionConfig(object):
 
     self.sm_root = Normalize(self.sm_root)
 
-  def detectMetaMod(self):
-    if builder.options.mms_path:
-      self.mms_root = builder.options.mms_path
-    else:
-      self.mms_root = ResolveEnvPath('MMSOURCE110', 'mmsource-1.10')
-      if not self.mms_root:
-        self.mms_root = ResolveEnvPath('MMSOURCE', 'metamod-source')
-      if not self.mms_root:
-        self.mms_root = ResolveEnvPath('MMSOURCE_DEV', 'mmsource-central')
-
   def detectBoost(self):
     if builder.options.boost_path:
       self.boost_root = builder.options.boost_path
+    else:
+      raise Exception('Could not find a copy of Boost')
 
   def configure(self):
     cxx = builder.DetectCompilers()
@@ -246,7 +237,6 @@ class ExtensionConfig(object):
     return binary
 
 Extension = ExtensionConfig()
-Extension.detectMetaMod()
 Extension.detectSourceMod()
 Extension.detectBoost()
 Extension.configure()

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -168,7 +168,7 @@ class ExtensionConfig(object):
     ]
     cxx.cxxflags += [
       '/EHsc',
-      # '/GR-', # boost needs RTTI enabled
+      '/GR-',
       '/TP',
     ]
     cxx.linkflags += [

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # SourceMod Socket Extension
-This has been forked from [sfPlayer´s origin Git repository](http://player.to/gitweb/index.cgi?p=sm-ext-socket.git). Get to the [AlliedModders forum thread](https://forums.alliedmods.net/showthread.php?t=67640) for more information.
+This has been forked from [sfPlayer's origin Git repository][socket-git].
+Get to the [AlliedModders forum thread][socket-am] for more information.
+
+[socket-git]: http://player.to/gitweb/index.cgi?p=sm-ext-socket.git
+[socket-am]: https://forums.alliedmods.net/showthread.php?t=67640
 
 ## Building with AMBuild
 
 ### Dependencies
-- [SourceMod][] (follow the instructions on [Building SourceMod][])
+- [SourceMod][] toolchain (follow the instructions on [Building SourceMod][] to set up your
+environment, if you haven't already)
 - [Boost][]
 
 [SourceMod]: https://github.com/alliedmodders/sourcemod/
@@ -16,10 +21,13 @@ This has been forked from [sfPlayer´s origin Git repository](http://player.to/g
 1. Configure Boost.
   - Download the release archive from the site and extract the archive to a location
   `${BOOST_PATH}`.  Set that location as your working directory.
-  - Run the `bootstrap` script for your platform to build `b2`.
-  - Invoke `b2 define=BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY address-model=32 link=static --build-dir=build/x86 --build-type=complete --stagedir=stage/x86 --with-thread --with-date_time --with-regex`
+  - Run the `bootstrap` script for your platform to build `b2`.  Pass `--with-toolset` with
+  either `msvc`, `gcc`, or `clang` depending on what compiler you plan on building with.
+  - Invoke `b2 define=BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY address-model=32 runtime-link=static link=static --build-dir=build/x86 --stagedir=stage/x86 --with-thread --with-date_time --with-regex`
   to build the required libraries in mixed RTTI mode (boost will use RTTI, the extension will
-  not).
+  not).  The configuration should build fully static x86 libraries on both Withdows and Linux,
+  with versioned filenames on the former and system names on the latter (which allows us to use
+  `-lboost_*` without additional extensions when setting up the link flags on `ambuild`).
     - If an existing build is present with a different configuration, use `-a` to force
     rebuilding the libraries.
 2. `cd build/` and run `../configure.py --sm-path ${SM_PATH} --boost-path ${BOOST_PATH}`

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-SourceMod Socket Extension
-==========================
+# SourceMod Socket Extension
 This has been forked from [sfPlayer´s origin Git repository](http://player.to/gitweb/index.cgi?p=sm-ext-socket.git). Get to the [AlliedModders forum thread](https://forums.alliedmods.net/showthread.php?t=67640) for more information.
 
-Dependencies for building
--------------------------
- * [SourceMod](https://github.com/alliedmodders/sourcemod)
- * [Boost](http://www.boost.org/)
- * ~~[msinttypes](https://code.google.com/p/msinttypes/)~~
+## Building with AMBuild
 
-Building on Windows
--------------------
-Set the following environment variables on your system:
- * `SOURCEMOD` - path to SourceMod (>= 1.5.x)  
- * `BOOST155` - path to boost libraries (>= 1.5.5)  
- *  ~~`MSINTTYPES` - path to latest version of msinttypes~~ (Replaced "stdlib.h" with \<cstdlib\>)
+### Dependencies
+- [SourceMod][] (follow the instructions on [Building SourceMod][])
+- [Boost][]
+
+[SourceMod]: https://github.com/alliedmodders/sourcemod/
+[Building SourceMod]: https://wiki.alliedmods.net/Building_SourceMod
+[Boost]: http://www.boost.org/
+
+### Configuration
+
+1. Configure Boost.
+  - Download the release archive from the site and extract the archive to a location
+  `${BOOST_PATH}`.
+  - Run the `bootstrap` script for your platform to build `b2`.
+  - Invoke `b2 --build-dir=build/x86 address-model=32 --build-type=complete --with-thread --with-date_time --with-regex -link=static --stagedir=stage/x86`
+2. Run `configure.py --sm-path ${SM_PATH} --boost-path ${BOOST_PATH}`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ This has been forked from [sfPlayer´s origin Git repository](http://player.to/g
 
 1. Configure Boost.
   - Download the release archive from the site and extract the archive to a location
-  `${BOOST_PATH}`.
+  `${BOOST_PATH}`.  Set that location as your working directory.
   - Run the `bootstrap` script for your platform to build `b2`.
-  - Invoke `b2 --build-dir=build/x86 address-model=32 --build-type=complete --with-thread --with-date_time --with-regex -link=static --stagedir=stage/x86`
-2. Run `configure.py --sm-path ${SM_PATH} --boost-path ${BOOST_PATH}`
+  - Invoke `b2 define=BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY address-model=32 link=static --build-dir=build/x86 --build-type=complete --stagedir=stage/x86 --with-thread --with-date_time --with-regex`
+  to build the required libraries in mixed RTTI mode (boost will use RTTI, the extension will
+  not).
+    - If an existing build is present with a different configuration, use `-a` to force
+    rebuilding the libraries.
+2. `cd build/` and run `../configure.py --sm-path ${SM_PATH} --boost-path ${BOOST_PATH}`
+3. `ambuild` as normal.

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ environment, if you haven't already)
 ### Configuration
 
 1. Configure Boost.
-  - Download the release archive from the site and extract the archive to a location
-  `${BOOST_PATH}`.  Set that location as your working directory.
-  - Run the `bootstrap` script for your platform to build `b2`.  Pass `--with-toolset` with
-  either `msvc`, `gcc`, or `clang` depending on what compiler you plan on building with.
-  - Invoke `b2 define=BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY address-model=32 runtime-link=static link=static --build-dir=build/x86 --stagedir=stage/x86 --with-thread --with-date_time --with-regex`
-  to build the required libraries in mixed RTTI mode (boost will use RTTI, the extension will
-  not).  The configuration should build fully static x86 libraries on both Withdows and Linux,
-  with versioned filenames on the former and system names on the latter (which allows us to use
-  `-lboost_*` without additional extensions when setting up the link flags on `ambuild`).
-    - If an existing build is present with a different configuration, use `-a` to force
-    rebuilding the libraries.
+    - Download the release archive from the site and extract the archive to a location
+    `${BOOST_PATH}`.  Set that location as your working directory.
+    - Run the `bootstrap` script for your platform to build `b2`.  Pass `--with-toolset` with
+    either `msvc`, `gcc`, or `clang` depending on what compiler you plan on building with.
+    - Invoke `b2 define=BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY address-model=32 runtime-link=static link=static --build-dir=build/x86 --stagedir=stage/x86 --with-thread --with-date_time --with-regex`
+    to build the required libraries in mixed RTTI mode (boost will use RTTI, the extension will
+    not).  The configuration should build fully static x86 libraries on both Withdows and Linux,
+    with versioned filenames on the former and system names on the latter (which allows us to
+    use `-lboost_*` without additional extensions when setting up the link flags on `ambuild`).
+        - If an existing build is present with a different configuration, use `-a` to force
+        rebuilding the libraries.
 2. `cd build/` and run `../configure.py --sm-path ${SM_PATH} --boost-path ${BOOST_PATH}`
 3. `ambuild` as normal.

--- a/configure.py
+++ b/configure.py
@@ -12,6 +12,8 @@ builder.options.add_option('--mms-path', type=str, dest='mms_path', default=None
                        help='Path to Metamod:Source')
 builder.options.add_option('--sm-path', type=str, dest='sm_path', default=None,
                        help='Path to SourceMod')
+builder.options.add_option('--boost-path', type=str, dest='boost_path', default=None,
+                       help='Path to Boost')
 builder.options.add_option('--enable-debug', action='store_const', const='1', dest='debug',
                        help='Enable debugging symbols')
 builder.options.add_option('--enable-optimize', action='store_const', const='1', dest='opt',

--- a/configure.py
+++ b/configure.py
@@ -6,10 +6,6 @@ from ambuild2 import run
 
 builder = run.PrepareBuild(sourcePath = sys.path[0])
 
-builder.options.add_option('--hl2sdk-root', type=str, dest='hl2sdk_root', default=None,
-		                   help='Root search folder for HL2SDKs')
-builder.options.add_option('--mms-path', type=str, dest='mms_path', default=None,
-                       help='Path to Metamod:Source')
 builder.options.add_option('--sm-path', type=str, dest='sm_path', default=None,
                        help='Path to SourceMod')
 builder.options.add_option('--boost-path', type=str, dest='boost_path', default=None,


### PR DESCRIPTION
PR makes both Windows and Linux use the release from https://www.boost.org/.  It introduces a new `configure.py` option `--boost-path` to specify the location of the extracted release, and updates the `AMBuildScript` to statically link the required libraries.

README is also updated with build instructions for AMBuild.

While I can successfully compile and load the extension on my Windows / Linux systems with the provided instructions, I don't have any plugins that use the extension.  pls test

Attached [package.zip](https://github.com/JoinedSenses/sm-ext-socket/files/4049274/package.zip)
