### PR TITLE
Fix uncaught exception crashing & fix build for SM 1.11

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -38,7 +38,7 @@ class ExtensionConfig(object):
     if builder.options.sm_path:
       self.sm_root = builder.options.sm_path
     else:
-      self.sm_root = ResolveEnvPath('SOURCEMOD18', 'sourcemod-1.8')
+      self.sm_root = ResolveEnvPath('SOURCEMOD18', 'sourcemod-1.11')
       if not self.sm_root:
         self.sm_root = ResolveEnvPath('SOURCEMOD', 'sourcemod')
       if not self.sm_root:
@@ -106,7 +106,7 @@ class ExtensionConfig(object):
       '-fvisibility=hidden',
     ]
     cxx.cxxflags += [
-      '-std=c++11',
+      '-std=c++14',
       # '-fno-exceptions',
       '-fno-threadsafe-statics',
       '-Wno-non-virtual-dtor',

--- a/SocketHandler.cpp
+++ b/SocketHandler.cpp
@@ -102,7 +102,15 @@ void SocketHandler::StopProcessing() {
 void SocketHandler::RunIoService() {
 	//boost::asio::io_service::work work(*ioService);
 	ioServiceWork = new boost::asio::io_service::work(*ioService);
-	ioService->run();
+
+	while (true) {
+		try {
+			ioService->run();
+			break;
+		}
+		catch (...)
+		{}
+	}
 }
 
 SocketWrapper* SocketHandler::GetSocketWrapper(const void* socket) {


### PR DESCRIPTION
Fixes [these crashes](https://crash.limetech.org/stats/socket.ext.%25/%25throw_exception%25?frame=any&limit=100). I'm a bit unsure if there is a better way of dealing with the exceptions, but I could not think of anything, and this is sufficient to resolve crashes and retry `run()` on exception.

Builds as requested in Discord: [bins.zip](https://github.com/JoinedSenses/sm-ext-socket/files/11361512/bins.zip)